### PR TITLE
Add pagination support for testers

### DIFF
--- a/src/main/java/com/test/testing/controller/TesterController.java
+++ b/src/main/java/com/test/testing/controller/TesterController.java
@@ -5,6 +5,8 @@ import com.test.testing.dto.TesterLogDTO;
 import com.test.testing.dto.NumbersDTO;
 import com.test.testing.service.TesterService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,6 +38,16 @@ public class TesterController {
     public ResponseEntity<?> getTesters() {
         return ResponseEntity.ok(testerService.getTesters());
     }
+
+/**
+ * Retrieves a paginated list of testers
+ * @param pageable the pagination information
+ * @return a page of tester DTOs
+ */
+ @GetMapping("/paginated")
+ public ResponseEntity<Page<TesterDTO>> getTestersWithPagination(Pageable pageable) {
+     return ResponseEntity.ok(testerService.getTestersWithPagination(pageable));
+ }
 
     @GetMapping("/numbers/params")
     public ResponseEntity<Map<String, List<String>>> getNumbersWithParams(

--- a/src/main/java/com/test/testing/repository/TesterRepository.java
+++ b/src/main/java/com/test/testing/repository/TesterRepository.java
@@ -1,6 +1,9 @@
 package com.test.testing.repository;
 
 import com.test.testing.entity.Tester;
+import com.test.testing.dto.TesterDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +14,7 @@ public interface TesterRepository extends BaseRepository<Tester> {
 
     @Query("SELECT t FROM Tester t WHERE (:name is NULL OR t.name LIKE %:name%)")
     List<Tester> findWithSearch(String name);
+
+    @Query("SELECT new com.test.testing.dto.TesterDTO(t.id, t.name, t.number) FROM Tester t")
+    Page<TesterDTO> findAllTestersWithPagination(Pageable pageable);
 }

--- a/src/main/java/com/test/testing/service/TesterService.java
+++ b/src/main/java/com/test/testing/service/TesterService.java
@@ -9,6 +9,8 @@ import com.test.testing.repository.TesterRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/src/main/java/com/test/testing/service/TesterService.java
+++ b/src/main/java/com/test/testing/service/TesterService.java
@@ -7,6 +7,8 @@ import com.test.testing.entity.TesterLog;
 import com.test.testing.repository.TesterLogRepository;
 import com.test.testing.repository.TesterRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -39,5 +41,9 @@ public class TesterService {
 
     public List<Tester> getTesters() {
         return testerRepository.findWithSearch(null);
+    }
+
+    public Page<TesterDTO> getTestersWithPagination(Pageable pageable) {
+        return testerRepository.findAllTestersWithPagination(pageable);
     }
 }


### PR DESCRIPTION
- Implemented a new endpoint in TesterController to retrieve a paginated list of testers.
- Updated TesterRepository with a query to fetch testers with pagination.
- Enhanced TesterService to support pagination functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new paginated endpoint for retrieving testers, allowing users to fetch tester data in pages for easier navigation and improved performance when handling large datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->